### PR TITLE
indexes are important

### DIFF
--- a/packages/bff-cli/deno.json
+++ b/packages/bff-cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigmoves/bff-cli",
-  "version": "0.3.0-beta.39",
+  "version": "0.3.0-beta.40",
   "license": "MIT",
   "imports": {
     "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",

--- a/packages/bff-cli/mod.ts
+++ b/packages/bff-cli/mod.ts
@@ -142,6 +142,7 @@ if (import.meta.main) {
       "collections",
       "repos",
       "external-collections",
+      "collection-key-map",
       "unstable-lexicons",
     ],
     alias: { h: "help" },
@@ -190,9 +191,13 @@ if (import.meta.main) {
       break;
     }
     case "sync": {
+      const collectionKeyMap = flags["collection-key-map"]
+        ? JSON.parse(flags["collection-key-map"])
+        : undefined;
       bff({
         appName: "CLI Sync",
         databaseUrl: flags.db,
+        collectionKeyMap,
         onListen: async ({ indexService, cfg }) => {
           await backfillCollections(
             indexService,

--- a/packages/bff/deno.json
+++ b/packages/bff/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigmoves/bff",
-  "version": "0.3.0-beta.39",
+  "version": "0.3.0-beta.40",
   "license": "MIT",
   "tasks": {
     "tailwind": "deno run -A --node-modules-dir npm:@tailwindcss/cli -i ./styles/input.css -o ./styles/output.css -m",

--- a/packages/bff/mod.tsx
+++ b/packages/bff/mod.tsx
@@ -281,7 +281,6 @@ function createDb(cfg: BffConfig) {
   return db;
 }
 
-// Update: buildWhereClause now takes a kvAliasMap for indexed keys
 function buildWhereClause(
   condition: Where,
   tableColumns: string[],

--- a/packages/bff/types.d.ts
+++ b/packages/bff/types.d.ts
@@ -91,6 +91,8 @@ export type BffOptions = {
    * @default "static"
    */
   buildDir?: string;
+  /** Collection key map. Define which key/value pairs to index. */
+  collectionKeyMap?: Record<string, string[]>;
   /** The root element of the app */
   rootElement?: RootElement;
   /** Called when the server starts listening. */
@@ -180,6 +182,16 @@ export type QueryOptions = {
   cursor?: string;
 };
 
+export type CollectionKeyMap = Record<string, string[]>;
+
+export type RecordKvTable = {
+  uri: string;
+  collection: string;
+  key: string;
+  value: string;
+  indexedAt: string;
+};
+
 export type IndexService = {
   getRecords: <T extends Record<string, unknown>>(
     collection: string,
@@ -190,7 +202,7 @@ export type IndexService = {
   ) => T | undefined;
   insertRecord: (record: RecordTable) => void;
   updateRecord: (record: RecordTable) => void;
-  updateRecords: (records: RecordTable[]) => void;
+  countRecords: (collection: string, options?: QueryOptions) => number;
   deleteRecord: (uri: string) => void;
   insertActor: (actor: ActorTable) => void;
   getActor: (did: string) => ActorTable | undefined;


### PR DESCRIPTION
Adds indexes for the record table.

Adds a `indexService.countRecords(...)` fn with the same args as `getRecords`.

Adds a new table `record_kv` to index key/value pairs specified in the config via `collectionKeyMap`. If any of these keys are used in count/getRecords queries the `record_kv` table is joined with `record` for fast lookups.